### PR TITLE
Transfer _bookdown.yml - fix leanpub render on _Quizzes repo 

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -78,6 +78,9 @@ jobs:
         run: |
           # Copy over images folder
           svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
+          
+          # Copy over _bookdown.yml 
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
@@ -96,6 +99,7 @@ jobs:
              It copies over the ottrpal-needed folder (for the `bookdown_to_embed_leanpub(render = FALSE)` function
              to run properly.
                - resources/chapt_screen_images/*
+               - _bookdown.yml
           labels: |
             automated
           reviewers: $GITHUB_ACTOR

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -1,7 +1,7 @@
 
 ##### Checks run at pull request #####
 # Check quiz formatting
-check-quizzes: yes
+check-quizzes: no
 # Check that urls in the content are not broken
 url-checker: yes
 # Render preview of content with changes (Rmd's and md's are checked)


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Render leanpub on FH_Cluster_Guide_Quizzes is not happening because of an error that the _bookdown.yml file is not there: 

https://github.com/fhdsl/FH_Cluster_Guide_Quizzes/actions/runs/3198705156/jobs/5223572231

So this is to make sure that file gets there so the render_leanpub happens and manuscript/ will be made and Leanpub can be published from that. 

I'll be making this same change on OTTR_Template: https://github.com/jhudsl/OTTR_Template/pull/574