### PR TITLE
Add blank target

### DIFF
--- a/01-101.Rmd
+++ b/01-101.Rmd
@@ -52,7 +52,7 @@ If one of your collaborators requires access to the Fred Hutch network you can s
 
 Your HutchNet ID must be associated with a PI cluster "account". The Scientific Computing Team (SciComp) tries to set users up with a connection to a PI account before they need it, but this is not automatic!  To ensure that you have been set up to use the cluster, please follow the following steps:
 
-1. Go to the [SciComp Self-Service Portal](https://scicomp-self-service.fredhutch.org/){:target="_blank"}
+1. Go to the <a href="https://scicomp-self-service.fredhutch.org/" target="_blank">SciComp Self-Service Portal</a>
 1. Click on "Check Access"
 1. Log in using your HutchNet ID and password
 

--- a/01-101.Rmd
+++ b/01-101.Rmd
@@ -52,7 +52,7 @@ If one of your collaborators requires access to the Fred Hutch network you can s
 
 Your HutchNet ID must be associated with a PI cluster "account". The Scientific Computing Team (SciComp) tries to set users up with a connection to a PI account before they need it, but this is not automatic!  To ensure that you have been set up to use the cluster, please follow the following steps:
 
-1. Go to the [SciComp Self-Service Portal](https://scicomp-self-service.fredhutch.org/)
+1. Go to the [SciComp Self-Service Portal](https://scicomp-self-service.fredhutch.org/){:target="_blank"}
 1. Click on "Check Access"
 1. Log in using your HutchNet ID and password
 


### PR DESCRIPTION
>  Is it possible to have the scicomp self-service link open a new tab when you click on it (instead of replacing the Cluster 101 book in the open tab)? Would be nice to be able to switch right back to Cluster 101 once you verify you have cluster access.