### PR TITLE
Remove option to get a sticker as someone who takes the course on the…

### DIFF
--- a/faq.Rmd
+++ b/faq.Rmd
@@ -83,6 +83,4 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1BQxrVYdKZTbpCaF-
     ```{r, echo=FALSE, fig.alt='The Generate Certificate button on the course summary page is highlighted.', out.width = '100%'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1BQxrVYdKZTbpCaF-i_q9w7s9x034lEXpQZDU-Sl09cs/edit#slide=id.g162fb43cc93_0_32")
     ```
-    
-[Contact the DaSL Team](mailto:data@fredhutch.org) to submit your Cluster 101 certificate for an awesome Hex Sticker!
 


### PR DESCRIPTION


Hi @laderast, this is a legacy line here from 3 years ago. We wanted to entice people to take the online course.

Sana reached out about this because someone requested a sticker. We can certainly remove this, if we only want to give stickers to those who take the workshop.

